### PR TITLE
Update PyPI URL in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,26 +17,26 @@ jobs:
     # Define the PyPI environment for trusted publishing
     environment:
       name: pypi
-      url: https://pypi.org/p/parquet-path-rewriter # URL to your package on PyPI
+      url: https://pypi.org/p/lambda-rag-lite # URL to your package on PyPI
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        # Use a recent Python version known to work well for building
-        python-version: '3.9'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          # Use a recent Python version known to work well for building
+          python-version: "3.9"
 
-    - name: Install build dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
 
-    - name: Build package
-      run: python -m build --sdist --wheel .
+      - name: Build package
+        run: python -m build --sdist --wheel .
 
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      # No API token needed here when using trusted publishing (permissions + environment)
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No API token needed here when using trusted publishing (permissions + environment)


### PR DESCRIPTION
Change the PyPI URL in the publishing workflow to reflect the correct package location.